### PR TITLE
Update aws_c_auth_jll to version 0.9.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibAwsAuth"
 uuid = "e028494f-7ddb-47cd-bd9c-7e7578dea4c5"
-version = "1.0.1"
+version = "1.0.2"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -21,7 +21,7 @@ LibAwsCompression = "1.1.0"
 LibAwsHTTP = "1.2.0"
 LibAwsIO = "1.1.0"
 LibAwsSdkutils = "1.1.0"
-aws_c_auth_jll = "=0.9.0"
+aws_c_auth_jll = "=0.9.1"
 julia = "1.6"
 
 [extras]

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -18,4 +18,4 @@ aws_c_sdkutils_jll = "1282aa60-004d-510b-9f52-12498d409daa"
 [compat]
 Clang = "0.18.3"
 JLLPrefixes = "0.3"
-aws_c_auth_jll = "=0.9.0"
+aws_c_auth_jll = "=0.9.1"

--- a/lib/aarch64-apple-darwin20.jl
+++ b/lib/aarch64-apple-darwin20.jl
@@ -2126,24 +2126,24 @@ Controls if signing adds a header containing the canonical request's body value
 end
 
 """
-    struct (unnamed at /home/runner/.julia/artifacts/7757ca2b625f95bf1868a5f07bc861e26e046001/include/aws/auth/signing_config.h:214:5)
+    struct (unnamed at /home/runner/.julia/artifacts/3f8268a0b2f1537aa7cc5a131cbcf9847082249a/include/aws/auth/signing_config.h:214:5)
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/7757ca2b625f95bf1868a5f07bc861e26e046001/include/aws/auth/signing_config.h:214:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/3f8268a0b2f1537aa7cc5a131cbcf9847082249a/include/aws/auth/signing_config.h:214:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/7757ca2b625f95bf1868a5f07bc861e26e046001/include/aws/auth/signing_config.h:214:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/3f8268a0b2f1537aa7cc5a131cbcf9847082249a/include/aws/auth/signing_config.h:214:5)"}, f::Symbol)
     f === :use_double_uri_encode && return (Ptr{UInt32}(x + 0), 0, 1)
     f === :should_normalize_uri_path && return (Ptr{UInt32}(x + 0), 1, 1)
     f === :omit_session_token && return (Ptr{UInt32}(x + 0), 2, 1)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"struct (unnamed at /home/runner/.julia/artifacts/7757ca2b625f95bf1868a5f07bc861e26e046001/include/aws/auth/signing_config.h:214:5)", f::Symbol)
-    r = Ref{var"struct (unnamed at /home/runner/.julia/artifacts/7757ca2b625f95bf1868a5f07bc861e26e046001/include/aws/auth/signing_config.h:214:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/7757ca2b625f95bf1868a5f07bc861e26e046001/include/aws/auth/signing_config.h:214:5)"}, r)
+function Base.getproperty(x::var"struct (unnamed at /home/runner/.julia/artifacts/3f8268a0b2f1537aa7cc5a131cbcf9847082249a/include/aws/auth/signing_config.h:214:5)", f::Symbol)
+    r = Ref{var"struct (unnamed at /home/runner/.julia/artifacts/3f8268a0b2f1537aa7cc5a131cbcf9847082249a/include/aws/auth/signing_config.h:214:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/3f8268a0b2f1537aa7cc5a131cbcf9847082249a/include/aws/auth/signing_config.h:214:5)"}, r)
     fptr = getproperty(ptr, f)
     begin
         if fptr isa Ptr
@@ -2162,7 +2162,7 @@ function Base.getproperty(x::var"struct (unnamed at /home/runner/.julia/artifact
     end
 end
 
-function Base.setproperty!(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/7757ca2b625f95bf1868a5f07bc861e26e046001/include/aws/auth/signing_config.h:214:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/3f8268a0b2f1537aa7cc5a131cbcf9847082249a/include/aws/auth/signing_config.h:214:5)"}, f::Symbol, v)
     fptr = getproperty(x, f)
     if fptr isa Ptr
         unsafe_store!(getproperty(x, f), v)
@@ -2202,7 +2202,7 @@ function Base.getproperty(x::Ptr{aws_signing_config_aws}, f::Symbol)
     f === :date && return Ptr{aws_date_time}(x + 48)
     f === :should_sign_header && return Ptr{Ptr{aws_should_sign_header_fn}}(x + 184)
     f === :should_sign_header_ud && return Ptr{Ptr{Cvoid}}(x + 192)
-    f === :flags && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/7757ca2b625f95bf1868a5f07bc861e26e046001/include/aws/auth/signing_config.h:214:5)"}(x + 200)
+    f === :flags && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/3f8268a0b2f1537aa7cc5a131cbcf9847082249a/include/aws/auth/signing_config.h:214:5)"}(x + 200)
     f === :signed_body_value && return Ptr{aws_byte_cursor}(x + 208)
     f === :signed_body_header && return Ptr{aws_signed_body_header_type}(x + 224)
     f === :credentials && return Ptr{Ptr{aws_credentials}}(x + 232)

--- a/lib/aarch64-linux-gnu.jl
+++ b/lib/aarch64-linux-gnu.jl
@@ -2126,24 +2126,24 @@ Controls if signing adds a header containing the canonical request's body value
 end
 
 """
-    struct (unnamed at /home/runner/.julia/artifacts/97ff7ece6b34d8817252ca6a5a89627386add524/include/aws/auth/signing_config.h:214:5)
+    struct (unnamed at /home/runner/.julia/artifacts/bc0e251e4a1a213fe5e152a2369d36c1aa9437e1/include/aws/auth/signing_config.h:214:5)
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/97ff7ece6b34d8817252ca6a5a89627386add524/include/aws/auth/signing_config.h:214:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/bc0e251e4a1a213fe5e152a2369d36c1aa9437e1/include/aws/auth/signing_config.h:214:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/97ff7ece6b34d8817252ca6a5a89627386add524/include/aws/auth/signing_config.h:214:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/bc0e251e4a1a213fe5e152a2369d36c1aa9437e1/include/aws/auth/signing_config.h:214:5)"}, f::Symbol)
     f === :use_double_uri_encode && return (Ptr{UInt32}(x + 0), 0, 1)
     f === :should_normalize_uri_path && return (Ptr{UInt32}(x + 0), 1, 1)
     f === :omit_session_token && return (Ptr{UInt32}(x + 0), 2, 1)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"struct (unnamed at /home/runner/.julia/artifacts/97ff7ece6b34d8817252ca6a5a89627386add524/include/aws/auth/signing_config.h:214:5)", f::Symbol)
-    r = Ref{var"struct (unnamed at /home/runner/.julia/artifacts/97ff7ece6b34d8817252ca6a5a89627386add524/include/aws/auth/signing_config.h:214:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/97ff7ece6b34d8817252ca6a5a89627386add524/include/aws/auth/signing_config.h:214:5)"}, r)
+function Base.getproperty(x::var"struct (unnamed at /home/runner/.julia/artifacts/bc0e251e4a1a213fe5e152a2369d36c1aa9437e1/include/aws/auth/signing_config.h:214:5)", f::Symbol)
+    r = Ref{var"struct (unnamed at /home/runner/.julia/artifacts/bc0e251e4a1a213fe5e152a2369d36c1aa9437e1/include/aws/auth/signing_config.h:214:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/bc0e251e4a1a213fe5e152a2369d36c1aa9437e1/include/aws/auth/signing_config.h:214:5)"}, r)
     fptr = getproperty(ptr, f)
     begin
         if fptr isa Ptr
@@ -2162,7 +2162,7 @@ function Base.getproperty(x::var"struct (unnamed at /home/runner/.julia/artifact
     end
 end
 
-function Base.setproperty!(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/97ff7ece6b34d8817252ca6a5a89627386add524/include/aws/auth/signing_config.h:214:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/bc0e251e4a1a213fe5e152a2369d36c1aa9437e1/include/aws/auth/signing_config.h:214:5)"}, f::Symbol, v)
     fptr = getproperty(x, f)
     if fptr isa Ptr
         unsafe_store!(getproperty(x, f), v)
@@ -2202,7 +2202,7 @@ function Base.getproperty(x::Ptr{aws_signing_config_aws}, f::Symbol)
     f === :date && return Ptr{aws_date_time}(x + 48)
     f === :should_sign_header && return Ptr{Ptr{aws_should_sign_header_fn}}(x + 184)
     f === :should_sign_header_ud && return Ptr{Ptr{Cvoid}}(x + 192)
-    f === :flags && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/97ff7ece6b34d8817252ca6a5a89627386add524/include/aws/auth/signing_config.h:214:5)"}(x + 200)
+    f === :flags && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/bc0e251e4a1a213fe5e152a2369d36c1aa9437e1/include/aws/auth/signing_config.h:214:5)"}(x + 200)
     f === :signed_body_value && return Ptr{aws_byte_cursor}(x + 208)
     f === :signed_body_header && return Ptr{aws_signed_body_header_type}(x + 224)
     f === :credentials && return Ptr{Ptr{aws_credentials}}(x + 232)

--- a/lib/aarch64-linux-musl.jl
+++ b/lib/aarch64-linux-musl.jl
@@ -2126,24 +2126,24 @@ Controls if signing adds a header containing the canonical request's body value
 end
 
 """
-    struct (unnamed at /home/runner/.julia/artifacts/3eeb1ab8f451f120fc659c990fbbb5bcc7048fc2/include/aws/auth/signing_config.h:214:5)
+    struct (unnamed at /home/runner/.julia/artifacts/a7e8822bdf4c14176cff3a4c71b4f3520fe7d8e5/include/aws/auth/signing_config.h:214:5)
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/3eeb1ab8f451f120fc659c990fbbb5bcc7048fc2/include/aws/auth/signing_config.h:214:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/a7e8822bdf4c14176cff3a4c71b4f3520fe7d8e5/include/aws/auth/signing_config.h:214:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/3eeb1ab8f451f120fc659c990fbbb5bcc7048fc2/include/aws/auth/signing_config.h:214:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/a7e8822bdf4c14176cff3a4c71b4f3520fe7d8e5/include/aws/auth/signing_config.h:214:5)"}, f::Symbol)
     f === :use_double_uri_encode && return (Ptr{UInt32}(x + 0), 0, 1)
     f === :should_normalize_uri_path && return (Ptr{UInt32}(x + 0), 1, 1)
     f === :omit_session_token && return (Ptr{UInt32}(x + 0), 2, 1)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"struct (unnamed at /home/runner/.julia/artifacts/3eeb1ab8f451f120fc659c990fbbb5bcc7048fc2/include/aws/auth/signing_config.h:214:5)", f::Symbol)
-    r = Ref{var"struct (unnamed at /home/runner/.julia/artifacts/3eeb1ab8f451f120fc659c990fbbb5bcc7048fc2/include/aws/auth/signing_config.h:214:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/3eeb1ab8f451f120fc659c990fbbb5bcc7048fc2/include/aws/auth/signing_config.h:214:5)"}, r)
+function Base.getproperty(x::var"struct (unnamed at /home/runner/.julia/artifacts/a7e8822bdf4c14176cff3a4c71b4f3520fe7d8e5/include/aws/auth/signing_config.h:214:5)", f::Symbol)
+    r = Ref{var"struct (unnamed at /home/runner/.julia/artifacts/a7e8822bdf4c14176cff3a4c71b4f3520fe7d8e5/include/aws/auth/signing_config.h:214:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/a7e8822bdf4c14176cff3a4c71b4f3520fe7d8e5/include/aws/auth/signing_config.h:214:5)"}, r)
     fptr = getproperty(ptr, f)
     begin
         if fptr isa Ptr
@@ -2162,7 +2162,7 @@ function Base.getproperty(x::var"struct (unnamed at /home/runner/.julia/artifact
     end
 end
 
-function Base.setproperty!(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/3eeb1ab8f451f120fc659c990fbbb5bcc7048fc2/include/aws/auth/signing_config.h:214:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/a7e8822bdf4c14176cff3a4c71b4f3520fe7d8e5/include/aws/auth/signing_config.h:214:5)"}, f::Symbol, v)
     fptr = getproperty(x, f)
     if fptr isa Ptr
         unsafe_store!(getproperty(x, f), v)
@@ -2202,7 +2202,7 @@ function Base.getproperty(x::Ptr{aws_signing_config_aws}, f::Symbol)
     f === :date && return Ptr{aws_date_time}(x + 48)
     f === :should_sign_header && return Ptr{Ptr{aws_should_sign_header_fn}}(x + 184)
     f === :should_sign_header_ud && return Ptr{Ptr{Cvoid}}(x + 192)
-    f === :flags && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/3eeb1ab8f451f120fc659c990fbbb5bcc7048fc2/include/aws/auth/signing_config.h:214:5)"}(x + 200)
+    f === :flags && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/a7e8822bdf4c14176cff3a4c71b4f3520fe7d8e5/include/aws/auth/signing_config.h:214:5)"}(x + 200)
     f === :signed_body_value && return Ptr{aws_byte_cursor}(x + 208)
     f === :signed_body_header && return Ptr{aws_signed_body_header_type}(x + 224)
     f === :credentials && return Ptr{Ptr{aws_credentials}}(x + 232)

--- a/lib/armv7l-linux-gnueabihf.jl
+++ b/lib/armv7l-linux-gnueabihf.jl
@@ -2126,24 +2126,24 @@ Controls if signing adds a header containing the canonical request's body value
 end
 
 """
-    struct (unnamed at /home/runner/.julia/artifacts/85dd811b90904c03d29eacec88d15269157f74d0/include/aws/auth/signing_config.h:214:5)
+    struct (unnamed at /home/runner/.julia/artifacts/feba58785f63f85740a79d74ed84e24f8491fcb1/include/aws/auth/signing_config.h:214:5)
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/85dd811b90904c03d29eacec88d15269157f74d0/include/aws/auth/signing_config.h:214:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/feba58785f63f85740a79d74ed84e24f8491fcb1/include/aws/auth/signing_config.h:214:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/85dd811b90904c03d29eacec88d15269157f74d0/include/aws/auth/signing_config.h:214:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/feba58785f63f85740a79d74ed84e24f8491fcb1/include/aws/auth/signing_config.h:214:5)"}, f::Symbol)
     f === :use_double_uri_encode && return (Ptr{UInt32}(x + 0), 0, 1)
     f === :should_normalize_uri_path && return (Ptr{UInt32}(x + 0), 1, 1)
     f === :omit_session_token && return (Ptr{UInt32}(x + 0), 2, 1)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"struct (unnamed at /home/runner/.julia/artifacts/85dd811b90904c03d29eacec88d15269157f74d0/include/aws/auth/signing_config.h:214:5)", f::Symbol)
-    r = Ref{var"struct (unnamed at /home/runner/.julia/artifacts/85dd811b90904c03d29eacec88d15269157f74d0/include/aws/auth/signing_config.h:214:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/85dd811b90904c03d29eacec88d15269157f74d0/include/aws/auth/signing_config.h:214:5)"}, r)
+function Base.getproperty(x::var"struct (unnamed at /home/runner/.julia/artifacts/feba58785f63f85740a79d74ed84e24f8491fcb1/include/aws/auth/signing_config.h:214:5)", f::Symbol)
+    r = Ref{var"struct (unnamed at /home/runner/.julia/artifacts/feba58785f63f85740a79d74ed84e24f8491fcb1/include/aws/auth/signing_config.h:214:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/feba58785f63f85740a79d74ed84e24f8491fcb1/include/aws/auth/signing_config.h:214:5)"}, r)
     fptr = getproperty(ptr, f)
     begin
         if fptr isa Ptr
@@ -2162,7 +2162,7 @@ function Base.getproperty(x::var"struct (unnamed at /home/runner/.julia/artifact
     end
 end
 
-function Base.setproperty!(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/85dd811b90904c03d29eacec88d15269157f74d0/include/aws/auth/signing_config.h:214:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/feba58785f63f85740a79d74ed84e24f8491fcb1/include/aws/auth/signing_config.h:214:5)"}, f::Symbol, v)
     fptr = getproperty(x, f)
     if fptr isa Ptr
         unsafe_store!(getproperty(x, f), v)
@@ -2202,7 +2202,7 @@ function Base.getproperty(x::Ptr{aws_signing_config_aws}, f::Symbol)
     f === :date && return Ptr{aws_date_time}(x + 28)
     f === :should_sign_header && return Ptr{Ptr{aws_should_sign_header_fn}}(x + 132)
     f === :should_sign_header_ud && return Ptr{Ptr{Cvoid}}(x + 136)
-    f === :flags && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/85dd811b90904c03d29eacec88d15269157f74d0/include/aws/auth/signing_config.h:214:5)"}(x + 140)
+    f === :flags && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/feba58785f63f85740a79d74ed84e24f8491fcb1/include/aws/auth/signing_config.h:214:5)"}(x + 140)
     f === :signed_body_value && return Ptr{aws_byte_cursor}(x + 144)
     f === :signed_body_header && return Ptr{aws_signed_body_header_type}(x + 152)
     f === :credentials && return Ptr{Ptr{aws_credentials}}(x + 156)

--- a/lib/armv7l-linux-musleabihf.jl
+++ b/lib/armv7l-linux-musleabihf.jl
@@ -2126,24 +2126,24 @@ Controls if signing adds a header containing the canonical request's body value
 end
 
 """
-    struct (unnamed at /home/runner/.julia/artifacts/a8d9de210de7cc28632668860865777e3bd3763e/include/aws/auth/signing_config.h:214:5)
+    struct (unnamed at /home/runner/.julia/artifacts/9115186549551779ba15c50e185bb7737bb372fc/include/aws/auth/signing_config.h:214:5)
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/a8d9de210de7cc28632668860865777e3bd3763e/include/aws/auth/signing_config.h:214:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/9115186549551779ba15c50e185bb7737bb372fc/include/aws/auth/signing_config.h:214:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/a8d9de210de7cc28632668860865777e3bd3763e/include/aws/auth/signing_config.h:214:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/9115186549551779ba15c50e185bb7737bb372fc/include/aws/auth/signing_config.h:214:5)"}, f::Symbol)
     f === :use_double_uri_encode && return (Ptr{UInt32}(x + 0), 0, 1)
     f === :should_normalize_uri_path && return (Ptr{UInt32}(x + 0), 1, 1)
     f === :omit_session_token && return (Ptr{UInt32}(x + 0), 2, 1)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"struct (unnamed at /home/runner/.julia/artifacts/a8d9de210de7cc28632668860865777e3bd3763e/include/aws/auth/signing_config.h:214:5)", f::Symbol)
-    r = Ref{var"struct (unnamed at /home/runner/.julia/artifacts/a8d9de210de7cc28632668860865777e3bd3763e/include/aws/auth/signing_config.h:214:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/a8d9de210de7cc28632668860865777e3bd3763e/include/aws/auth/signing_config.h:214:5)"}, r)
+function Base.getproperty(x::var"struct (unnamed at /home/runner/.julia/artifacts/9115186549551779ba15c50e185bb7737bb372fc/include/aws/auth/signing_config.h:214:5)", f::Symbol)
+    r = Ref{var"struct (unnamed at /home/runner/.julia/artifacts/9115186549551779ba15c50e185bb7737bb372fc/include/aws/auth/signing_config.h:214:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/9115186549551779ba15c50e185bb7737bb372fc/include/aws/auth/signing_config.h:214:5)"}, r)
     fptr = getproperty(ptr, f)
     begin
         if fptr isa Ptr
@@ -2162,7 +2162,7 @@ function Base.getproperty(x::var"struct (unnamed at /home/runner/.julia/artifact
     end
 end
 
-function Base.setproperty!(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/a8d9de210de7cc28632668860865777e3bd3763e/include/aws/auth/signing_config.h:214:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/9115186549551779ba15c50e185bb7737bb372fc/include/aws/auth/signing_config.h:214:5)"}, f::Symbol, v)
     fptr = getproperty(x, f)
     if fptr isa Ptr
         unsafe_store!(getproperty(x, f), v)
@@ -2202,7 +2202,7 @@ function Base.getproperty(x::Ptr{aws_signing_config_aws}, f::Symbol)
     f === :date && return Ptr{aws_date_time}(x + 28)
     f === :should_sign_header && return Ptr{Ptr{aws_should_sign_header_fn}}(x + 132)
     f === :should_sign_header_ud && return Ptr{Ptr{Cvoid}}(x + 136)
-    f === :flags && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/a8d9de210de7cc28632668860865777e3bd3763e/include/aws/auth/signing_config.h:214:5)"}(x + 140)
+    f === :flags && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/9115186549551779ba15c50e185bb7737bb372fc/include/aws/auth/signing_config.h:214:5)"}(x + 140)
     f === :signed_body_value && return Ptr{aws_byte_cursor}(x + 144)
     f === :signed_body_header && return Ptr{aws_signed_body_header_type}(x + 152)
     f === :credentials && return Ptr{Ptr{aws_credentials}}(x + 156)

--- a/lib/i686-linux-gnu.jl
+++ b/lib/i686-linux-gnu.jl
@@ -2126,24 +2126,24 @@ Controls if signing adds a header containing the canonical request's body value
 end
 
 """
-    struct (unnamed at /home/runner/.julia/artifacts/e4716f0aaac68d0487f6ca198c09c972f94fc598/include/aws/auth/signing_config.h:214:5)
+    struct (unnamed at /home/runner/.julia/artifacts/a894941e1f6d122b4ef7df38f0cc3e0e62bc81f8/include/aws/auth/signing_config.h:214:5)
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/e4716f0aaac68d0487f6ca198c09c972f94fc598/include/aws/auth/signing_config.h:214:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/a894941e1f6d122b4ef7df38f0cc3e0e62bc81f8/include/aws/auth/signing_config.h:214:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/e4716f0aaac68d0487f6ca198c09c972f94fc598/include/aws/auth/signing_config.h:214:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/a894941e1f6d122b4ef7df38f0cc3e0e62bc81f8/include/aws/auth/signing_config.h:214:5)"}, f::Symbol)
     f === :use_double_uri_encode && return (Ptr{UInt32}(x + 0), 0, 1)
     f === :should_normalize_uri_path && return (Ptr{UInt32}(x + 0), 1, 1)
     f === :omit_session_token && return (Ptr{UInt32}(x + 0), 2, 1)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"struct (unnamed at /home/runner/.julia/artifacts/e4716f0aaac68d0487f6ca198c09c972f94fc598/include/aws/auth/signing_config.h:214:5)", f::Symbol)
-    r = Ref{var"struct (unnamed at /home/runner/.julia/artifacts/e4716f0aaac68d0487f6ca198c09c972f94fc598/include/aws/auth/signing_config.h:214:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/e4716f0aaac68d0487f6ca198c09c972f94fc598/include/aws/auth/signing_config.h:214:5)"}, r)
+function Base.getproperty(x::var"struct (unnamed at /home/runner/.julia/artifacts/a894941e1f6d122b4ef7df38f0cc3e0e62bc81f8/include/aws/auth/signing_config.h:214:5)", f::Symbol)
+    r = Ref{var"struct (unnamed at /home/runner/.julia/artifacts/a894941e1f6d122b4ef7df38f0cc3e0e62bc81f8/include/aws/auth/signing_config.h:214:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/a894941e1f6d122b4ef7df38f0cc3e0e62bc81f8/include/aws/auth/signing_config.h:214:5)"}, r)
     fptr = getproperty(ptr, f)
     begin
         if fptr isa Ptr
@@ -2162,7 +2162,7 @@ function Base.getproperty(x::var"struct (unnamed at /home/runner/.julia/artifact
     end
 end
 
-function Base.setproperty!(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/e4716f0aaac68d0487f6ca198c09c972f94fc598/include/aws/auth/signing_config.h:214:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/a894941e1f6d122b4ef7df38f0cc3e0e62bc81f8/include/aws/auth/signing_config.h:214:5)"}, f::Symbol, v)
     fptr = getproperty(x, f)
     if fptr isa Ptr
         unsafe_store!(getproperty(x, f), v)
@@ -2202,7 +2202,7 @@ function Base.getproperty(x::Ptr{aws_signing_config_aws}, f::Symbol)
     f === :date && return Ptr{aws_date_time}(x + 28)
     f === :should_sign_header && return Ptr{Ptr{aws_should_sign_header_fn}}(x + 132)
     f === :should_sign_header_ud && return Ptr{Ptr{Cvoid}}(x + 136)
-    f === :flags && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/e4716f0aaac68d0487f6ca198c09c972f94fc598/include/aws/auth/signing_config.h:214:5)"}(x + 140)
+    f === :flags && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/a894941e1f6d122b4ef7df38f0cc3e0e62bc81f8/include/aws/auth/signing_config.h:214:5)"}(x + 140)
     f === :signed_body_value && return Ptr{aws_byte_cursor}(x + 144)
     f === :signed_body_header && return Ptr{aws_signed_body_header_type}(x + 152)
     f === :credentials && return Ptr{Ptr{aws_credentials}}(x + 156)

--- a/lib/i686-linux-musl.jl
+++ b/lib/i686-linux-musl.jl
@@ -2126,24 +2126,24 @@ Controls if signing adds a header containing the canonical request's body value
 end
 
 """
-    struct (unnamed at /home/runner/.julia/artifacts/a371459b2023d371bb0e44cc6edcc375e8005860/include/aws/auth/signing_config.h:214:5)
+    struct (unnamed at /home/runner/.julia/artifacts/65e67cdd58bc218fe8c82065225c7a35b0b58df9/include/aws/auth/signing_config.h:214:5)
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/a371459b2023d371bb0e44cc6edcc375e8005860/include/aws/auth/signing_config.h:214:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/65e67cdd58bc218fe8c82065225c7a35b0b58df9/include/aws/auth/signing_config.h:214:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/a371459b2023d371bb0e44cc6edcc375e8005860/include/aws/auth/signing_config.h:214:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/65e67cdd58bc218fe8c82065225c7a35b0b58df9/include/aws/auth/signing_config.h:214:5)"}, f::Symbol)
     f === :use_double_uri_encode && return (Ptr{UInt32}(x + 0), 0, 1)
     f === :should_normalize_uri_path && return (Ptr{UInt32}(x + 0), 1, 1)
     f === :omit_session_token && return (Ptr{UInt32}(x + 0), 2, 1)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"struct (unnamed at /home/runner/.julia/artifacts/a371459b2023d371bb0e44cc6edcc375e8005860/include/aws/auth/signing_config.h:214:5)", f::Symbol)
-    r = Ref{var"struct (unnamed at /home/runner/.julia/artifacts/a371459b2023d371bb0e44cc6edcc375e8005860/include/aws/auth/signing_config.h:214:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/a371459b2023d371bb0e44cc6edcc375e8005860/include/aws/auth/signing_config.h:214:5)"}, r)
+function Base.getproperty(x::var"struct (unnamed at /home/runner/.julia/artifacts/65e67cdd58bc218fe8c82065225c7a35b0b58df9/include/aws/auth/signing_config.h:214:5)", f::Symbol)
+    r = Ref{var"struct (unnamed at /home/runner/.julia/artifacts/65e67cdd58bc218fe8c82065225c7a35b0b58df9/include/aws/auth/signing_config.h:214:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/65e67cdd58bc218fe8c82065225c7a35b0b58df9/include/aws/auth/signing_config.h:214:5)"}, r)
     fptr = getproperty(ptr, f)
     begin
         if fptr isa Ptr
@@ -2162,7 +2162,7 @@ function Base.getproperty(x::var"struct (unnamed at /home/runner/.julia/artifact
     end
 end
 
-function Base.setproperty!(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/a371459b2023d371bb0e44cc6edcc375e8005860/include/aws/auth/signing_config.h:214:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/65e67cdd58bc218fe8c82065225c7a35b0b58df9/include/aws/auth/signing_config.h:214:5)"}, f::Symbol, v)
     fptr = getproperty(x, f)
     if fptr isa Ptr
         unsafe_store!(getproperty(x, f), v)
@@ -2202,7 +2202,7 @@ function Base.getproperty(x::Ptr{aws_signing_config_aws}, f::Symbol)
     f === :date && return Ptr{aws_date_time}(x + 28)
     f === :should_sign_header && return Ptr{Ptr{aws_should_sign_header_fn}}(x + 132)
     f === :should_sign_header_ud && return Ptr{Ptr{Cvoid}}(x + 136)
-    f === :flags && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/a371459b2023d371bb0e44cc6edcc375e8005860/include/aws/auth/signing_config.h:214:5)"}(x + 140)
+    f === :flags && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/65e67cdd58bc218fe8c82065225c7a35b0b58df9/include/aws/auth/signing_config.h:214:5)"}(x + 140)
     f === :signed_body_value && return Ptr{aws_byte_cursor}(x + 144)
     f === :signed_body_header && return Ptr{aws_signed_body_header_type}(x + 152)
     f === :credentials && return Ptr{Ptr{aws_credentials}}(x + 156)

--- a/lib/powerpc64le-linux-gnu.jl
+++ b/lib/powerpc64le-linux-gnu.jl
@@ -2126,24 +2126,24 @@ Controls if signing adds a header containing the canonical request's body value
 end
 
 """
-    struct (unnamed at /home/runner/.julia/artifacts/62e17a45dd619e3a00bb5a356aec46e6b0c1d225/include/aws/auth/signing_config.h:214:5)
+    struct (unnamed at /home/runner/.julia/artifacts/61f6439970df8e6d5ce069abb528d9fb94f886d8/include/aws/auth/signing_config.h:214:5)
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/62e17a45dd619e3a00bb5a356aec46e6b0c1d225/include/aws/auth/signing_config.h:214:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/61f6439970df8e6d5ce069abb528d9fb94f886d8/include/aws/auth/signing_config.h:214:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/62e17a45dd619e3a00bb5a356aec46e6b0c1d225/include/aws/auth/signing_config.h:214:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/61f6439970df8e6d5ce069abb528d9fb94f886d8/include/aws/auth/signing_config.h:214:5)"}, f::Symbol)
     f === :use_double_uri_encode && return (Ptr{UInt32}(x + 0), 0, 1)
     f === :should_normalize_uri_path && return (Ptr{UInt32}(x + 0), 1, 1)
     f === :omit_session_token && return (Ptr{UInt32}(x + 0), 2, 1)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"struct (unnamed at /home/runner/.julia/artifacts/62e17a45dd619e3a00bb5a356aec46e6b0c1d225/include/aws/auth/signing_config.h:214:5)", f::Symbol)
-    r = Ref{var"struct (unnamed at /home/runner/.julia/artifacts/62e17a45dd619e3a00bb5a356aec46e6b0c1d225/include/aws/auth/signing_config.h:214:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/62e17a45dd619e3a00bb5a356aec46e6b0c1d225/include/aws/auth/signing_config.h:214:5)"}, r)
+function Base.getproperty(x::var"struct (unnamed at /home/runner/.julia/artifacts/61f6439970df8e6d5ce069abb528d9fb94f886d8/include/aws/auth/signing_config.h:214:5)", f::Symbol)
+    r = Ref{var"struct (unnamed at /home/runner/.julia/artifacts/61f6439970df8e6d5ce069abb528d9fb94f886d8/include/aws/auth/signing_config.h:214:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/61f6439970df8e6d5ce069abb528d9fb94f886d8/include/aws/auth/signing_config.h:214:5)"}, r)
     fptr = getproperty(ptr, f)
     begin
         if fptr isa Ptr
@@ -2162,7 +2162,7 @@ function Base.getproperty(x::var"struct (unnamed at /home/runner/.julia/artifact
     end
 end
 
-function Base.setproperty!(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/62e17a45dd619e3a00bb5a356aec46e6b0c1d225/include/aws/auth/signing_config.h:214:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/61f6439970df8e6d5ce069abb528d9fb94f886d8/include/aws/auth/signing_config.h:214:5)"}, f::Symbol, v)
     fptr = getproperty(x, f)
     if fptr isa Ptr
         unsafe_store!(getproperty(x, f), v)
@@ -2202,7 +2202,7 @@ function Base.getproperty(x::Ptr{aws_signing_config_aws}, f::Symbol)
     f === :date && return Ptr{aws_date_time}(x + 48)
     f === :should_sign_header && return Ptr{Ptr{aws_should_sign_header_fn}}(x + 184)
     f === :should_sign_header_ud && return Ptr{Ptr{Cvoid}}(x + 192)
-    f === :flags && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/62e17a45dd619e3a00bb5a356aec46e6b0c1d225/include/aws/auth/signing_config.h:214:5)"}(x + 200)
+    f === :flags && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/61f6439970df8e6d5ce069abb528d9fb94f886d8/include/aws/auth/signing_config.h:214:5)"}(x + 200)
     f === :signed_body_value && return Ptr{aws_byte_cursor}(x + 208)
     f === :signed_body_header && return Ptr{aws_signed_body_header_type}(x + 224)
     f === :credentials && return Ptr{Ptr{aws_credentials}}(x + 232)

--- a/lib/x86_64-apple-darwin14.jl
+++ b/lib/x86_64-apple-darwin14.jl
@@ -2126,24 +2126,24 @@ Controls if signing adds a header containing the canonical request's body value
 end
 
 """
-    struct (unnamed at /home/runner/.julia/artifacts/ff77ca1034e55d6fb8671df09f48e8435f4f15c2/include/aws/auth/signing_config.h:214:5)
+    struct (unnamed at /home/runner/.julia/artifacts/b1f96a134af72723f84612f9d21ba30f291850b5/include/aws/auth/signing_config.h:214:5)
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/ff77ca1034e55d6fb8671df09f48e8435f4f15c2/include/aws/auth/signing_config.h:214:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/b1f96a134af72723f84612f9d21ba30f291850b5/include/aws/auth/signing_config.h:214:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/ff77ca1034e55d6fb8671df09f48e8435f4f15c2/include/aws/auth/signing_config.h:214:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/b1f96a134af72723f84612f9d21ba30f291850b5/include/aws/auth/signing_config.h:214:5)"}, f::Symbol)
     f === :use_double_uri_encode && return (Ptr{UInt32}(x + 0), 0, 1)
     f === :should_normalize_uri_path && return (Ptr{UInt32}(x + 0), 1, 1)
     f === :omit_session_token && return (Ptr{UInt32}(x + 0), 2, 1)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"struct (unnamed at /home/runner/.julia/artifacts/ff77ca1034e55d6fb8671df09f48e8435f4f15c2/include/aws/auth/signing_config.h:214:5)", f::Symbol)
-    r = Ref{var"struct (unnamed at /home/runner/.julia/artifacts/ff77ca1034e55d6fb8671df09f48e8435f4f15c2/include/aws/auth/signing_config.h:214:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/ff77ca1034e55d6fb8671df09f48e8435f4f15c2/include/aws/auth/signing_config.h:214:5)"}, r)
+function Base.getproperty(x::var"struct (unnamed at /home/runner/.julia/artifacts/b1f96a134af72723f84612f9d21ba30f291850b5/include/aws/auth/signing_config.h:214:5)", f::Symbol)
+    r = Ref{var"struct (unnamed at /home/runner/.julia/artifacts/b1f96a134af72723f84612f9d21ba30f291850b5/include/aws/auth/signing_config.h:214:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/b1f96a134af72723f84612f9d21ba30f291850b5/include/aws/auth/signing_config.h:214:5)"}, r)
     fptr = getproperty(ptr, f)
     begin
         if fptr isa Ptr
@@ -2162,7 +2162,7 @@ function Base.getproperty(x::var"struct (unnamed at /home/runner/.julia/artifact
     end
 end
 
-function Base.setproperty!(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/ff77ca1034e55d6fb8671df09f48e8435f4f15c2/include/aws/auth/signing_config.h:214:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/b1f96a134af72723f84612f9d21ba30f291850b5/include/aws/auth/signing_config.h:214:5)"}, f::Symbol, v)
     fptr = getproperty(x, f)
     if fptr isa Ptr
         unsafe_store!(getproperty(x, f), v)
@@ -2202,7 +2202,7 @@ function Base.getproperty(x::Ptr{aws_signing_config_aws}, f::Symbol)
     f === :date && return Ptr{aws_date_time}(x + 48)
     f === :should_sign_header && return Ptr{Ptr{aws_should_sign_header_fn}}(x + 184)
     f === :should_sign_header_ud && return Ptr{Ptr{Cvoid}}(x + 192)
-    f === :flags && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/ff77ca1034e55d6fb8671df09f48e8435f4f15c2/include/aws/auth/signing_config.h:214:5)"}(x + 200)
+    f === :flags && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/b1f96a134af72723f84612f9d21ba30f291850b5/include/aws/auth/signing_config.h:214:5)"}(x + 200)
     f === :signed_body_value && return Ptr{aws_byte_cursor}(x + 208)
     f === :signed_body_header && return Ptr{aws_signed_body_header_type}(x + 224)
     f === :credentials && return Ptr{Ptr{aws_credentials}}(x + 232)

--- a/lib/x86_64-linux-gnu.jl
+++ b/lib/x86_64-linux-gnu.jl
@@ -2126,24 +2126,24 @@ Controls if signing adds a header containing the canonical request's body value
 end
 
 """
-    struct (unnamed at /home/runner/.julia/artifacts/b2ced2585edc49fe2f249c066810ccdc07bf1dcc/include/aws/auth/signing_config.h:214:5)
+    struct (unnamed at /home/runner/.julia/artifacts/2cb41a456a10dcd7a3a7145ce96a12d0c8c71636/include/aws/auth/signing_config.h:214:5)
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/b2ced2585edc49fe2f249c066810ccdc07bf1dcc/include/aws/auth/signing_config.h:214:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/2cb41a456a10dcd7a3a7145ce96a12d0c8c71636/include/aws/auth/signing_config.h:214:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/b2ced2585edc49fe2f249c066810ccdc07bf1dcc/include/aws/auth/signing_config.h:214:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/2cb41a456a10dcd7a3a7145ce96a12d0c8c71636/include/aws/auth/signing_config.h:214:5)"}, f::Symbol)
     f === :use_double_uri_encode && return (Ptr{UInt32}(x + 0), 0, 1)
     f === :should_normalize_uri_path && return (Ptr{UInt32}(x + 0), 1, 1)
     f === :omit_session_token && return (Ptr{UInt32}(x + 0), 2, 1)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"struct (unnamed at /home/runner/.julia/artifacts/b2ced2585edc49fe2f249c066810ccdc07bf1dcc/include/aws/auth/signing_config.h:214:5)", f::Symbol)
-    r = Ref{var"struct (unnamed at /home/runner/.julia/artifacts/b2ced2585edc49fe2f249c066810ccdc07bf1dcc/include/aws/auth/signing_config.h:214:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/b2ced2585edc49fe2f249c066810ccdc07bf1dcc/include/aws/auth/signing_config.h:214:5)"}, r)
+function Base.getproperty(x::var"struct (unnamed at /home/runner/.julia/artifacts/2cb41a456a10dcd7a3a7145ce96a12d0c8c71636/include/aws/auth/signing_config.h:214:5)", f::Symbol)
+    r = Ref{var"struct (unnamed at /home/runner/.julia/artifacts/2cb41a456a10dcd7a3a7145ce96a12d0c8c71636/include/aws/auth/signing_config.h:214:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/2cb41a456a10dcd7a3a7145ce96a12d0c8c71636/include/aws/auth/signing_config.h:214:5)"}, r)
     fptr = getproperty(ptr, f)
     begin
         if fptr isa Ptr
@@ -2162,7 +2162,7 @@ function Base.getproperty(x::var"struct (unnamed at /home/runner/.julia/artifact
     end
 end
 
-function Base.setproperty!(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/b2ced2585edc49fe2f249c066810ccdc07bf1dcc/include/aws/auth/signing_config.h:214:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/2cb41a456a10dcd7a3a7145ce96a12d0c8c71636/include/aws/auth/signing_config.h:214:5)"}, f::Symbol, v)
     fptr = getproperty(x, f)
     if fptr isa Ptr
         unsafe_store!(getproperty(x, f), v)
@@ -2202,7 +2202,7 @@ function Base.getproperty(x::Ptr{aws_signing_config_aws}, f::Symbol)
     f === :date && return Ptr{aws_date_time}(x + 48)
     f === :should_sign_header && return Ptr{Ptr{aws_should_sign_header_fn}}(x + 184)
     f === :should_sign_header_ud && return Ptr{Ptr{Cvoid}}(x + 192)
-    f === :flags && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/b2ced2585edc49fe2f249c066810ccdc07bf1dcc/include/aws/auth/signing_config.h:214:5)"}(x + 200)
+    f === :flags && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/2cb41a456a10dcd7a3a7145ce96a12d0c8c71636/include/aws/auth/signing_config.h:214:5)"}(x + 200)
     f === :signed_body_value && return Ptr{aws_byte_cursor}(x + 208)
     f === :signed_body_header && return Ptr{aws_signed_body_header_type}(x + 224)
     f === :credentials && return Ptr{Ptr{aws_credentials}}(x + 232)

--- a/lib/x86_64-linux-musl.jl
+++ b/lib/x86_64-linux-musl.jl
@@ -2126,24 +2126,24 @@ Controls if signing adds a header containing the canonical request's body value
 end
 
 """
-    struct (unnamed at /home/runner/.julia/artifacts/48780d0236476d36fed1a8b73a47d217ca685522/include/aws/auth/signing_config.h:214:5)
+    struct (unnamed at /home/runner/.julia/artifacts/7e73ee0871c4493c01591485f46db6cae2ca5b68/include/aws/auth/signing_config.h:214:5)
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/48780d0236476d36fed1a8b73a47d217ca685522/include/aws/auth/signing_config.h:214:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/7e73ee0871c4493c01591485f46db6cae2ca5b68/include/aws/auth/signing_config.h:214:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/48780d0236476d36fed1a8b73a47d217ca685522/include/aws/auth/signing_config.h:214:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/7e73ee0871c4493c01591485f46db6cae2ca5b68/include/aws/auth/signing_config.h:214:5)"}, f::Symbol)
     f === :use_double_uri_encode && return (Ptr{UInt32}(x + 0), 0, 1)
     f === :should_normalize_uri_path && return (Ptr{UInt32}(x + 0), 1, 1)
     f === :omit_session_token && return (Ptr{UInt32}(x + 0), 2, 1)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"struct (unnamed at /home/runner/.julia/artifacts/48780d0236476d36fed1a8b73a47d217ca685522/include/aws/auth/signing_config.h:214:5)", f::Symbol)
-    r = Ref{var"struct (unnamed at /home/runner/.julia/artifacts/48780d0236476d36fed1a8b73a47d217ca685522/include/aws/auth/signing_config.h:214:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/48780d0236476d36fed1a8b73a47d217ca685522/include/aws/auth/signing_config.h:214:5)"}, r)
+function Base.getproperty(x::var"struct (unnamed at /home/runner/.julia/artifacts/7e73ee0871c4493c01591485f46db6cae2ca5b68/include/aws/auth/signing_config.h:214:5)", f::Symbol)
+    r = Ref{var"struct (unnamed at /home/runner/.julia/artifacts/7e73ee0871c4493c01591485f46db6cae2ca5b68/include/aws/auth/signing_config.h:214:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/7e73ee0871c4493c01591485f46db6cae2ca5b68/include/aws/auth/signing_config.h:214:5)"}, r)
     fptr = getproperty(ptr, f)
     begin
         if fptr isa Ptr
@@ -2162,7 +2162,7 @@ function Base.getproperty(x::var"struct (unnamed at /home/runner/.julia/artifact
     end
 end
 
-function Base.setproperty!(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/48780d0236476d36fed1a8b73a47d217ca685522/include/aws/auth/signing_config.h:214:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/7e73ee0871c4493c01591485f46db6cae2ca5b68/include/aws/auth/signing_config.h:214:5)"}, f::Symbol, v)
     fptr = getproperty(x, f)
     if fptr isa Ptr
         unsafe_store!(getproperty(x, f), v)
@@ -2202,7 +2202,7 @@ function Base.getproperty(x::Ptr{aws_signing_config_aws}, f::Symbol)
     f === :date && return Ptr{aws_date_time}(x + 48)
     f === :should_sign_header && return Ptr{Ptr{aws_should_sign_header_fn}}(x + 184)
     f === :should_sign_header_ud && return Ptr{Ptr{Cvoid}}(x + 192)
-    f === :flags && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/48780d0236476d36fed1a8b73a47d217ca685522/include/aws/auth/signing_config.h:214:5)"}(x + 200)
+    f === :flags && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/7e73ee0871c4493c01591485f46db6cae2ca5b68/include/aws/auth/signing_config.h:214:5)"}(x + 200)
     f === :signed_body_value && return Ptr{aws_byte_cursor}(x + 208)
     f === :signed_body_header && return Ptr{aws_signed_body_header_type}(x + 224)
     f === :credentials && return Ptr{Ptr{aws_credentials}}(x + 232)

--- a/lib/x86_64-unknown-freebsd13.2.jl
+++ b/lib/x86_64-unknown-freebsd13.2.jl
@@ -2126,24 +2126,24 @@ Controls if signing adds a header containing the canonical request's body value
 end
 
 """
-    struct (unnamed at /home/runner/.julia/artifacts/2c4204854b6f4df93b1ffea9c7ca8b4d7f9cae4d/include/aws/auth/signing_config.h:214:5)
+    struct (unnamed at /home/runner/.julia/artifacts/6fd9642d5b189c355996bd5eca14cf184e29b103/include/aws/auth/signing_config.h:214:5)
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/2c4204854b6f4df93b1ffea9c7ca8b4d7f9cae4d/include/aws/auth/signing_config.h:214:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/6fd9642d5b189c355996bd5eca14cf184e29b103/include/aws/auth/signing_config.h:214:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/2c4204854b6f4df93b1ffea9c7ca8b4d7f9cae4d/include/aws/auth/signing_config.h:214:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/6fd9642d5b189c355996bd5eca14cf184e29b103/include/aws/auth/signing_config.h:214:5)"}, f::Symbol)
     f === :use_double_uri_encode && return (Ptr{UInt32}(x + 0), 0, 1)
     f === :should_normalize_uri_path && return (Ptr{UInt32}(x + 0), 1, 1)
     f === :omit_session_token && return (Ptr{UInt32}(x + 0), 2, 1)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"struct (unnamed at /home/runner/.julia/artifacts/2c4204854b6f4df93b1ffea9c7ca8b4d7f9cae4d/include/aws/auth/signing_config.h:214:5)", f::Symbol)
-    r = Ref{var"struct (unnamed at /home/runner/.julia/artifacts/2c4204854b6f4df93b1ffea9c7ca8b4d7f9cae4d/include/aws/auth/signing_config.h:214:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/2c4204854b6f4df93b1ffea9c7ca8b4d7f9cae4d/include/aws/auth/signing_config.h:214:5)"}, r)
+function Base.getproperty(x::var"struct (unnamed at /home/runner/.julia/artifacts/6fd9642d5b189c355996bd5eca14cf184e29b103/include/aws/auth/signing_config.h:214:5)", f::Symbol)
+    r = Ref{var"struct (unnamed at /home/runner/.julia/artifacts/6fd9642d5b189c355996bd5eca14cf184e29b103/include/aws/auth/signing_config.h:214:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/6fd9642d5b189c355996bd5eca14cf184e29b103/include/aws/auth/signing_config.h:214:5)"}, r)
     fptr = getproperty(ptr, f)
     begin
         if fptr isa Ptr
@@ -2162,7 +2162,7 @@ function Base.getproperty(x::var"struct (unnamed at /home/runner/.julia/artifact
     end
 end
 
-function Base.setproperty!(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/2c4204854b6f4df93b1ffea9c7ca8b4d7f9cae4d/include/aws/auth/signing_config.h:214:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/6fd9642d5b189c355996bd5eca14cf184e29b103/include/aws/auth/signing_config.h:214:5)"}, f::Symbol, v)
     fptr = getproperty(x, f)
     if fptr isa Ptr
         unsafe_store!(getproperty(x, f), v)
@@ -2202,7 +2202,7 @@ function Base.getproperty(x::Ptr{aws_signing_config_aws}, f::Symbol)
     f === :date && return Ptr{aws_date_time}(x + 48)
     f === :should_sign_header && return Ptr{Ptr{aws_should_sign_header_fn}}(x + 184)
     f === :should_sign_header_ud && return Ptr{Ptr{Cvoid}}(x + 192)
-    f === :flags && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/2c4204854b6f4df93b1ffea9c7ca8b4d7f9cae4d/include/aws/auth/signing_config.h:214:5)"}(x + 200)
+    f === :flags && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/6fd9642d5b189c355996bd5eca14cf184e29b103/include/aws/auth/signing_config.h:214:5)"}(x + 200)
     f === :signed_body_value && return Ptr{aws_byte_cursor}(x + 208)
     f === :signed_body_header && return Ptr{aws_signed_body_header_type}(x + 224)
     f === :credentials && return Ptr{Ptr{aws_credentials}}(x + 232)

--- a/lib/x86_64-w64-mingw32.jl
+++ b/lib/x86_64-w64-mingw32.jl
@@ -2158,24 +2158,24 @@ Controls if signing adds a header containing the canonical request's body value
 end
 
 """
-    struct (unnamed at /home/runner/.julia/artifacts/6dd82841e625f5e7f446e8b0636926c5adcb9f97/include/aws/auth/signing_config.h:214:5)
+    struct (unnamed at /home/runner/.julia/artifacts/3535fa64ff666f2b16eaf85ce67d9a43ab4ec5c3/include/aws/auth/signing_config.h:214:5)
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/6dd82841e625f5e7f446e8b0636926c5adcb9f97/include/aws/auth/signing_config.h:214:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/3535fa64ff666f2b16eaf85ce67d9a43ab4ec5c3/include/aws/auth/signing_config.h:214:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/6dd82841e625f5e7f446e8b0636926c5adcb9f97/include/aws/auth/signing_config.h:214:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/3535fa64ff666f2b16eaf85ce67d9a43ab4ec5c3/include/aws/auth/signing_config.h:214:5)"}, f::Symbol)
     f === :use_double_uri_encode && return (Ptr{UInt32}(x + 0), 0, 1)
     f === :should_normalize_uri_path && return (Ptr{UInt32}(x + 0), 1, 1)
     f === :omit_session_token && return (Ptr{UInt32}(x + 0), 2, 1)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"struct (unnamed at /home/runner/.julia/artifacts/6dd82841e625f5e7f446e8b0636926c5adcb9f97/include/aws/auth/signing_config.h:214:5)", f::Symbol)
-    r = Ref{var"struct (unnamed at /home/runner/.julia/artifacts/6dd82841e625f5e7f446e8b0636926c5adcb9f97/include/aws/auth/signing_config.h:214:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/6dd82841e625f5e7f446e8b0636926c5adcb9f97/include/aws/auth/signing_config.h:214:5)"}, r)
+function Base.getproperty(x::var"struct (unnamed at /home/runner/.julia/artifacts/3535fa64ff666f2b16eaf85ce67d9a43ab4ec5c3/include/aws/auth/signing_config.h:214:5)", f::Symbol)
+    r = Ref{var"struct (unnamed at /home/runner/.julia/artifacts/3535fa64ff666f2b16eaf85ce67d9a43ab4ec5c3/include/aws/auth/signing_config.h:214:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/3535fa64ff666f2b16eaf85ce67d9a43ab4ec5c3/include/aws/auth/signing_config.h:214:5)"}, r)
     fptr = getproperty(ptr, f)
     begin
         if fptr isa Ptr
@@ -2194,7 +2194,7 @@ function Base.getproperty(x::var"struct (unnamed at /home/runner/.julia/artifact
     end
 end
 
-function Base.setproperty!(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/6dd82841e625f5e7f446e8b0636926c5adcb9f97/include/aws/auth/signing_config.h:214:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/3535fa64ff666f2b16eaf85ce67d9a43ab4ec5c3/include/aws/auth/signing_config.h:214:5)"}, f::Symbol, v)
     fptr = getproperty(x, f)
     if fptr isa Ptr
         unsafe_store!(getproperty(x, f), v)
@@ -2234,7 +2234,7 @@ function Base.getproperty(x::Ptr{aws_signing_config_aws}, f::Symbol)
     f === :date && return Ptr{aws_date_time}(x + 48)
     f === :should_sign_header && return Ptr{Ptr{aws_should_sign_header_fn}}(x + 144)
     f === :should_sign_header_ud && return Ptr{Ptr{Cvoid}}(x + 152)
-    f === :flags && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/6dd82841e625f5e7f446e8b0636926c5adcb9f97/include/aws/auth/signing_config.h:214:5)"}(x + 160)
+    f === :flags && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/3535fa64ff666f2b16eaf85ce67d9a43ab4ec5c3/include/aws/auth/signing_config.h:214:5)"}(x + 160)
     f === :signed_body_value && return Ptr{aws_byte_cursor}(x + 168)
     f === :signed_body_header && return Ptr{aws_signed_body_header_type}(x + 184)
     f === :credentials && return Ptr{Ptr{aws_credentials}}(x + 192)


### PR DESCRIPTION
This PR updates the JLL dependency and regenerates bindings automatically.

- Updated **aws_c_auth_jll** to version **0.9.1**
- Updated **JuliaServices/LibAwsAuth.jl** version number
- **Bindings regeneration:**
  - ✅ Updated bindings